### PR TITLE
Fix Concurrency and Image Errors

### DIFF
--- a/app/handler/image.go
+++ b/app/handler/image.go
@@ -55,8 +55,8 @@ func AddText(fileName string, x, y int, labels []string,
 	if body != nil {
 		_, err = io.Copy(outFile, body)
 		if err != nil {
-			log.Println(err)
-			ch <- fileName
+			log.Println(fileName, err)
+			ch <- ""
 			return
 		}
 	}
@@ -69,8 +69,8 @@ func AddText(fileName string, x, y int, labels []string,
 			outFile.Seek(0, 0)
 			bg, err = png.Decode(outFile)
 			if err != nil {
-				log.Println(err)
-				ch <- fileName
+				log.Println(fileName, err)
+				ch <- ""
 				return
 			}
 		}
@@ -80,14 +80,14 @@ func AddText(fileName string, x, y int, labels []string,
 	// Read the font data.
 	fontBytes, err := ioutil.ReadFile(fontfile)
 	if err != nil {
-		log.Println(err)
-		ch <- fileName
+		log.Println(fileName, err)
+		ch <- ""
 		return
 	}
 	f, err := freetype.ParseFont(fontBytes)
 	if err != nil {
-		log.Println(err)
-		ch <- fileName
+		log.Println(fileName, err)
+		ch <- ""
 		return
 	}
 
@@ -113,8 +113,8 @@ func AddText(fileName string, x, y int, labels []string,
 	// Save that RGBA image to disk.
 	outFile, err = os.Create(fileName)
 	if err != nil {
-		log.Println(err)
-		ch <- fileName
+		log.Println(fileName, err)
+		ch <- ""
 		return
 	}
 
@@ -130,14 +130,14 @@ func AddText(fileName string, x, y int, labels []string,
 	b := bufio.NewWriter(outFile)
 	err = png.Encode(b, rgba)
 	if err != nil {
-		log.Println(err)
-		ch <- fileName
+		log.Println(fileName, err)
+		ch <- ""
 		return
 	}
 	err = b.Flush()
 	if err != nil {
-		log.Println(err)
-		ch <- fileName
+		log.Println(fileName, err)
+		ch <- ""
 		return
 	}
 	if ch != nil {

--- a/app/handler/userInfo.go
+++ b/app/handler/userInfo.go
@@ -17,7 +17,7 @@ import (
 )
 
 // GetAlbums maps the album data to the album object
-func GetAlbums(size int, albumData []byte) []model.Album {
+func GetAlbums(sizeSq int, albumData []byte) []model.Album {
 	var result map[string]map[string][]map[string]interface{}
 	json.Unmarshal(albumData, &result)
 	var albums []model.Album
@@ -35,9 +35,12 @@ func GetAlbums(size int, albumData []byte) []model.Album {
 		albums = append(albums, album)
 	}
 	ch := make(chan string)
-	downloadImages(albums[0:(size)], ch)
-	for i := 0; i < size; i++ {
-		<-ch
+	downloadImages(albums[0:(sizeSq)], ch)
+	for i := 0; i < sizeSq; i++ {
+		v := <-ch
+		if v == "" {
+			log.Printf("Error generating %s\n", v)
+		}
 	}
 	close(ch)
 	return albums
@@ -63,7 +66,6 @@ func downloadImages(albums []model.Album, ch chan string) {
 					ch)
 			} else {
 				go func() {
-					log.Printf(album.LocalImage)
 					ch <- album.LocalImage
 				}()
 			}

--- a/app/handler/userInfo.go
+++ b/app/handler/userInfo.go
@@ -79,7 +79,8 @@ func GetTopAlbums(w http.ResponseWriter, r *http.Request) {
 	case "overall":
 		break
 	default:
-		http.Error(w, `Invalid Param wanted 7day, 1month, 3month, 6month, 12month, or overall`, http.StatusUnprocessableEntity)
+		http.Error(w, `Invalid Param wanted 7day, 1month, 3month, 6month, 12month, or overall`,
+			http.StatusUnprocessableEntity)
 		return
 	}
 	URL := "http://ws.audioscrobbler.com/2.0/?method=user.gettopalbums&user=" +
@@ -114,7 +115,8 @@ func GetTopAlbums(w http.ResponseWriter, r *http.Request) {
 		}
 		png.Encode(w, image)
 	} else {
-		http.Error(w, vars["size"]+" invalid, needs to be between 0 and 7", http.StatusUnprocessableEntity)
+		http.Error(w, vars["size"]+" invalid, needs to be between 0 and 7",
+			http.StatusUnprocessableEntity)
 		return
 	}
 }


### PR DESCRIPTION
Image errors regenerates a new image with no background.
Only generate as many images as needed for image
Album generation now requires the size squared as a parameter